### PR TITLE
Improve GMM initialization

### DIFF
--- a/include/pgmlink/merger_resolving.h
+++ b/include/pgmlink/merger_resolving.h
@@ -320,22 +320,20 @@ class FeatureExtractorMCOMsFromGMM
 ////
 //// FeatureExtractorArmadillo
 ////
-class FeatureExtractorArmadillo 
-: public FeatureExtractorBase 
+class FeatureExtractorArmadillo
+    : public FeatureExtractorBase
 {
- public:
-  PGMLINK_EXPORT FeatureExtractorArmadillo(TimestepIdCoordinateMapPtr coordinates);
-  PGMLINK_EXPORT virtual std::vector<Traxel> operator()(Traxel& trax, size_t nMergers, unsigned int max_id);
- private:
-  void update_coordinates(const Traxel& trax,
-                          size_t nMergers,
-                          unsigned int max_id,
-                          arma::Col<size_t> labels);
-  FeatureExtractorArmadillo();
-  TimestepIdCoordinateMapPtr coordinates_;
+public:
+    PGMLINK_EXPORT FeatureExtractorArmadillo(TimestepIdCoordinateMapPtr coordinates);
+    PGMLINK_EXPORT virtual std::vector<Traxel> operator()(Traxel& trax, size_t nMergers, unsigned int max_id);
+private:
+    void update_coordinates(const Traxel& trax,
+                            size_t nMergers,
+                            unsigned int max_id,
+                            arma::Col<size_t>& labels);
+    FeatureExtractorArmadillo();
+    TimestepIdCoordinateMapPtr coordinates_;
 };
-  
-
 
 ////
 //// DistanceBase

--- a/include/pgmlink/merger_resolving.h
+++ b/include/pgmlink/merger_resolving.h
@@ -161,7 +161,9 @@ class GMM
     
 };
 
-
+/**
+ * @brief GMM that can be initialized with means, covariances and weights
+ */
 class GMMWithInitialized 
 : public ClusteringMlpackBase 
 {
@@ -169,29 +171,44 @@ class GMMWithInitialized
   GMMWithInitialized();
   int k_;
   int n_;
-  const feature_array& data_;
+  int n_iterations_;
+  double threshold_;
+
+  // store pointer to data, which could be either given as feature array or armadillo matrix
+  const feature_array* data_;
+  const arma::mat* arma_data_;
+
   double score_;
   int n_trials_;
   const std::vector<arma::vec>& means_;
   const std::vector<arma::mat>& covs_;
   const arma::vec& weights_;
+  arma::Col<size_t> labels_;
  public:
   // constructor needs to specify number of dimensions
   // for 2D data, ilastik provides coordinates with 3rd dimension 0
   // which will cause singular covariance matrix
   // therefore add option for dimensionality
+  PGMLINK_EXPORT GMMWithInitialized(int k, int n, const arma::mat& data, int n_trials,
+                                    const std::vector<arma::vec>& means, 
+                                    const std::vector<arma::mat>& covs, const arma::vec& weights)
+  : k_(k), n_(n), data_(NULL), arma_data_(&data), score_(0.0), n_trials_(n_trials), means_(means), covs_(covs), weights_(weights), n_iterations_(30), threshold_(0.000001)
+  {}
+
   PGMLINK_EXPORT GMMWithInitialized(int k, int n, const feature_array& data, int n_trials,
                                     const std::vector<arma::vec>& means, 
                                     const std::vector<arma::mat>& covs, const arma::vec& weights)
-  : k_(k), n_(n), data_(data), score_(0.0), n_trials_(n_trials), means_(means), covs_(covs), weights_(weights) 
+  : k_(k), n_(n), data_(&data), arma_data_(NULL), score_(0.0), n_trials_(n_trials), means_(means), covs_(covs), weights_(weights) , n_iterations_(30), threshold_(0.000001)
   {}
 
   PGMLINK_EXPORT virtual feature_array operator()();
   PGMLINK_EXPORT double score() const;
-    
+  PGMLINK_EXPORT arma::Col<size_t> labels() const;  
 };
 
-
+/**
+ * @brief GMM that uses armadillo matrices as input data
+ */
 class GMMInitializeArma 
 : public ClusteringMlpackBase 
 {
@@ -264,6 +281,18 @@ void get_centers(const arma::Mat<T>& data, const arma::Col<size_t> labels, arma:
 class FeatureExtractorBase {
  public:
   virtual std::vector<Traxel> operator()(Traxel& trax, size_t nMergers, unsigned int max_id) = 0;
+
+  // add version that also takes an initialization - but ignores it by default
+  virtual std::vector<Traxel> operator()(Traxel& trax,
+                                         size_t nMergers,
+                                         unsigned int max_id,
+                                         const std::vector<arma::vec>& means, 
+                                         const std::vector<arma::mat>& covs, 
+                                         const arma::vec& weights)
+  {
+    return operator()(trax, nMergers, max_id);
+  }
+
  protected:
 };
 
@@ -326,11 +355,21 @@ class FeatureExtractorArmadillo
 public:
     PGMLINK_EXPORT FeatureExtractorArmadillo(TimestepIdCoordinateMapPtr coordinates);
     PGMLINK_EXPORT virtual std::vector<Traxel> operator()(Traxel& trax, size_t nMergers, unsigned int max_id);
+    PGMLINK_EXPORT virtual std::vector<Traxel> operator() (Traxel& trax,
+                                                   size_t nMergers,
+                                                   unsigned int max_id,
+                                                   const std::vector<arma::vec>& means, 
+                                                   const std::vector<arma::mat>& covs, 
+                                                   const arma::vec& weights);
 private:
     void update_coordinates(const Traxel& trax,
                             size_t nMergers,
                             unsigned int max_id,
                             arma::Col<size_t>& labels);
+    void kmeansFallback(size_t nMergers, 
+                        arma::Col<size_t>& labels, 
+                        feature_array& merger_coms, 
+                        const arma::mat& coords);
     FeatureExtractorArmadillo();
     TimestepIdCoordinateMapPtr coordinates_;
 };
@@ -378,7 +417,8 @@ class FeatureHandlerBase
                           int timestep,
                           const std::vector<HypothesesGraph::base_graph::Arc>& sources,
                           const std::vector<HypothesesGraph::base_graph::Arc>& targets,
-                          std::vector<unsigned int>& new_ids
+                          std::vector<unsigned int>& new_ids,
+                          size_t n_dimensions
                           ) = 0;
 };
 
@@ -408,7 +448,8 @@ class FeatureHandlerFromTraxels
                           int timestep,
                           const std::vector<HypothesesGraph::base_graph::Arc>& sources,
                           const std::vector<HypothesesGraph::base_graph::Arc>& targets,
-                          std::vector<unsigned int>& new_ids
+                          std::vector<unsigned int>& new_ids,
+                          size_t n_dimensions
                           );
 };
 
@@ -432,7 +473,8 @@ class MergerResolver
 {
  private:
   HypothesesGraph* g_;
-    
+  size_t n_dimensions_;
+
   // default constructor should be private (no object without specified graph allowed)
   MergerResolver();
     
@@ -469,8 +511,8 @@ class MergerResolver
                    FeatureHandlerBase& handler);
 
  public:
-  PGMLINK_EXPORT MergerResolver(HypothesesGraph* g) 
-  : g_(g)
+  PGMLINK_EXPORT MergerResolver(HypothesesGraph* g, size_t num_dimensions) 
+  : g_(g), n_dimensions_(num_dimensions)
   {
     if (!g_)
       throw std::runtime_error("HypotesesGraph* g_ is a null pointer!");

--- a/include/pgmlink/merger_resolving.h
+++ b/include/pgmlink/merger_resolving.h
@@ -414,40 +414,6 @@ class FeatureHandlerFromTraxels
 
 
 ////
-//// ResolveAmbiguousArcsBase
-////
-class ResolveAmbiguousArcsBase {
- public:
-  virtual HypothesesGraph& operator()(HypothesesGraph* g) = 0;
-};
-  
-
-////
-//// ResolveAmbiguousArcsGreedy
-////
-class ResolveAmbiguousArcsGreedy 
-: public ResolveAmbiguousArcsBase 
-{
- public:
-  PGMLINK_EXPORT virtual HypothesesGraph& operator()(HypothesesGraph* g);
-};
-
-
-////
-//// ReasonerMaxOneArc
-////
-class ReasonerMaxOneArc : public Reasoner {
-};
-  
-
-////
-//// ResolveAmbiguousArcsPgm
-////
-class ResolveAmbiguousArcsPgm : public ReasonerMaxOneArc, private ResolveAmbiguousArcsBase {
-};
-
-
-////
 //// MergerResolver
 ////
 /**
@@ -955,7 +921,25 @@ void update_labelimage(const TimestepIdCoordinateMapPtr& coordinates,
    traxel_map.set(node, trax);
    } */
 
-  
+/**
+ * @brief Output std vectors of stuff
+ * 
+ * @param stream output stream
+ * @param feats the vector of stuff
+ */
+template<class T>
+std::ostream& operator<<(std::ostream& stream, const std::vector<T>& feats)
+{
+  stream << "(";
+  for(typename std::vector<T>::const_iterator f_it = feats.begin(); f_it != feats.end(); ++f_it)
+  {
+    if(f_it != feats.begin())
+      stream << ", ";
+    stream << *f_it;
+  }
+  stream << ")";
+  return stream;
+}
   
 }
 

--- a/include/pgmlink/merger_resolving_grammar.h
+++ b/include/pgmlink/merger_resolving_grammar.h
@@ -59,14 +59,6 @@ namespace pgmlink {
 
   class DistanceFromCOMs;
 
-  class ResolveAmbiguousArcsBase;
-
-  class ResolveAmbiguousArcsGreedy;
-
-  class ResolveAmbiguousArcsPgm;
-
-  class ReasonerMaxOneArc;
-
   class MergerResolver;
 
 }

--- a/src/merger_resolving.cpp
+++ b/src/merger_resolving.cpp
@@ -102,27 +102,48 @@ double GMM::score() const {
 ////
 feature_array GMMWithInitialized::operator()() {
   mlpack::gmm::GMM<> gmm(means_, covs_, weights_);
-  int n_samples = data_.size()/3;
-  arma::mat data(n_,n_samples);
-  arma::Col<size_t> labels;
-  LOG(logDEBUG1) << "GMMWithInitialized::operator(): n_=" << n_;
-  if (n_ == 2) {
-    feature_array_to_arma_mat_skip_last_dimension(data_, data, 3);
-  } else if(n_ == 3) {
-    feature_array_to_arma_mat(data_, data);
-  } else {
-    throw std::runtime_error("Number of spatial dimensions other than 2 or 3 would not make sense!");
-  }
-  score_ = gmm.Estimate(data, n_trials_);
-  std::vector<arma::vec> centers = gmm.Means();
-  feature_array fa_centers;
-  for (std::vector<arma::vec>::iterator it = centers.begin(); it != centers.end(); ++it) {
-    std::copy(it->begin(), it->end(), std::back_insert_iterator<feature_array >(fa_centers));
+
+  const arma::mat* data = arma_data_;
+  arma::mat* localData = NULL;
+
+  if(data == NULL)
+  {
+    assert(data_ != NULL);
+    int n_samples = data_->size()/3;
+    localData = new arma::mat(n_,n_samples);
     if (n_ == 2) {
-      fa_centers.push_back(0);
+      feature_array_to_arma_mat_skip_last_dimension(*data_, *localData, 3);
+    } else if(n_ == 3) {
+      feature_array_to_arma_mat(*data_, *localData);
+    } else {
+      throw std::runtime_error("Number of spatial dimensions other than 2 or 3 would not make sense!");
     }
+    data = localData;
   }
-  return fa_centers;
+  else
+    assert(data_ == NULL);
+  
+  LOG(logDEBUG1) << "GMMWithInitialized::operator(): n_=" << n_;
+  gmm.Fitter().MaxIterations() = n_iterations_;
+  gmm.Fitter().Tolerance() = threshold_;
+  score_ = gmm.Estimate(*data, n_trials_, true);
+  gmm.Classify(*data, labels_);
+  std::vector<arma::vec> centers = gmm.Means();
+  
+  // copy found cluster centers to stl vector
+  feature_array ret(3*k_, 0);
+  std::vector<arma::vec>::const_iterator it = centers.begin();
+  for (size_t cluster = 0; cluster < centers.size(); ++cluster, ++it) {
+    LOG(logDEBUG4) << "GMMInitializeArma::operator() -- copying cluster " << cluster
+                   << " to feature array ret with size " << ret.size();
+    std::copy(it->begin(), it->end(), ret.begin() + 3*cluster);
+  }
+
+  // clean up temporary arma matrix if we had to create it ourselves
+  if(localData != NULL)
+    delete localData;
+
+  return ret;
 }
 
 
@@ -133,6 +154,9 @@ double GMMWithInitialized::score() const {
   return score_;
 }
 
+arma::Col<size_t> GMMWithInitialized::labels() const {
+  return labels_;
+}
 
 ////
 //// GMMInitializeArma
@@ -300,6 +324,72 @@ FeatureExtractorArmadillo::FeatureExtractorArmadillo(TimestepIdCoordinateMapPtr 
 
 }
 
+void FeatureExtractorArmadillo::kmeansFallback(size_t nMergers, arma::Col<size_t>& labels, feature_array& merger_coms, const arma::mat& coords)
+{
+    // get pixel labels, and if one label did not get assigned to any pixels, run kmeans and use its assignments as labels
+    arma::Col<size_t> unique_labels = arma::unique(labels);
+    if(unique_labels.n_elem != nMergers)
+    {
+        LOG(logDEBUG1) << "Falling back to kmeans pixel labeling, as GMMs did not assign each label to at least one pixel";
+        arma::mat centers(3, nMergers);
+        mlpack::kmeans::KMeans<> kMeans;
+        kMeans.Cluster(coords, nMergers, labels, centers);
+        merger_coms.clear();
+        for (size_t c = 0; c < nMergers; c++)
+        {
+            for(size_t r = 0; r < centers.n_rows; r++)
+                merger_coms.push_back(centers(0,c));
+            for(size_t r = centers.n_rows; r < 3; r++)
+                merger_coms.push_back(0.0);
+        }
+    }
+}
+
+std::vector<Traxel> FeatureExtractorArmadillo::operator() (Traxel& trax,
+                                                           size_t nMergers,
+                                                           unsigned int max_id,
+                                                           const std::vector<arma::vec>& means, 
+                                                           const std::vector<arma::mat>& covs, 
+                                                           const arma::vec& weights
+                                                           )
+{
+    LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() with initialization -- entered for " << trax;
+    TimestepIdCoordinateMap::const_iterator it = coordinates_->find(std::make_pair(trax.Timestep, trax.Id));
+    if (it == coordinates_->end())
+    {
+        std::stringstream msg;
+        msg << "Traxel not found in coordinates: Timestep=" << trax.Timestep << " Id=" << trax.Id;
+        throw std::runtime_error(msg.str());
+    }
+    LOG(logDEBUG4) << "FeatureExtractorArmadillo::operator() -- coordinate list for " << trax
+                   << " has " << it->second.n_cols << " dimensions and "
+                   << it->second.n_rows << " points.";
+    size_t nTrials = 1;
+    // GMMInitializeArma gmm(nMergers, it->second);
+    GMMWithInitialized gmm(nMergers, it->second.n_cols, it->second, nTrials, means, covs, weights);
+    feature_array merger_coms;
+    arma::Col<size_t> labels;
+    try
+    {
+         merger_coms = gmm();
+         labels = gmm.labels();
+    }
+    catch(std::exception& e)
+    {
+        LOG(logWARNING) << "GMM fitting failed for " << trax << ", reverting to KMeans: " << e.what();
+    }
+
+    // if GMM failed, use KMeans
+    kmeansFallback(nMergers, labels, merger_coms, it->second);
+
+    // update coordinates and traxels based on this information
+    update_coordinates(trax, nMergers, max_id, labels);
+    trax.features["mergerCOMs"] = merger_coms;
+    FeatureExtractorMCOMsFromMCOMs extractor;
+    LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() -- exit";
+    return extractor(trax, nMergers, max_id);
+}
+
 
 std::vector<Traxel> FeatureExtractorArmadillo::operator() (Traxel& trax,
                                                            size_t nMergers,
@@ -329,22 +419,8 @@ std::vector<Traxel> FeatureExtractorArmadillo::operator() (Traxel& trax,
         LOG(logWARNING) << "GMM fitting failed for " << trax << ", reverting to KMeans: " << e.what();
     }
 
-    // get pixel labels, and if one label did not get assigned to any pixels, run kmeans and use its assignments as labels
-    arma::Col<size_t> unique_labels = arma::unique(labels);
-    if(unique_labels.n_elem != nMergers)
-    {
-        LOG(logINFO) << "Falling back to kmeans pixel labeling for " << trax << ", as GMMs did not assign each label to at least one pixel";
-        arma::mat centers(3, nMergers);
-        mlpack::kmeans::KMeans<> kMeans;
-        kMeans.Cluster(it->second, nMergers, labels, centers);
-        merger_coms.clear();
-        for (size_t c = 0; c < nMergers; c++)
-        {
-            merger_coms.push_back(centers(0,c));
-            merger_coms.push_back(centers(1,c));
-            merger_coms.push_back(centers(2,c));
-        }
-    }
+    // if GMM failed, use KMeans
+    kmeansFallback(nMergers, labels, merger_coms, it->second);
 
     // update coordinates and traxels based on this information
     update_coordinates(trax, nMergers, max_id, labels);
@@ -437,8 +513,9 @@ void FeatureHandlerFromTraxels::operator()(
     int timestep,
     const std::vector<HypothesesGraph::base_graph::Arc>& sources,
     const std::vector<HypothesesGraph::base_graph::Arc>& targets,
-    std::vector<unsigned int>& new_ids
-                                           ) {
+    std::vector<unsigned int>& new_ids,
+    size_t n_dimensions
+) {
   
   // property maps
   property_map<node_active2, HypothesesGraph::base_graph>::type& active_map = g.get(node_active2());
@@ -448,11 +525,40 @@ void FeatureHandlerFromTraxels::operator()(
   property_map<node_resolution_candidate, HypothesesGraph::base_graph>::type& node_resolution_map = g.get(node_resolution_candidate());
 
   // traxel and vector of replacement traxels
+  std::vector<Traxel> ft;
   Traxel trax = traxel_map[n];
-  LOG(logDEBUG3) << "FeatureHandlerFromTraxel::operator() -- entered for " << trax;
-  std::vector<Traxel> ft = extractor_(trax, n_merger, max_id);
-  LOG(logDEBUG3) << "FeatureHandlerFromTraxel::operator() -- got " << ft.size() << " new traxels";
-  // MAYBE LOG
+    
+  // get initialization for GMM fitting from incoming arcs
+  if(sources.size() == n_merger)
+  {
+    std::vector<arma::vec> initial_centers;
+    std::vector<arma::mat> initial_covs;
+    arma::vec initial_weights(n_merger);
+    
+    // fit GMM to each incoming detection? (must have been a non-merger if num active in arcs = num objects)
+    // or simply use center as a first try...
+    
+    for(size_t curr_idx = 0; curr_idx < sources.size(); ++curr_idx)
+    {
+      const feature_array& com = traxel_map[g.source(sources[curr_idx])].features.find("com")->second;
+      initial_centers.push_back(arma::vec(n_dimensions));
+      std::copy(com.begin(), com.begin()+n_dimensions, initial_centers.rbegin()->begin());
+      initial_covs.push_back(arma::eye(n_dimensions, n_dimensions));
+      initial_weights[curr_idx] = 1.0/n_merger;
+    }
+
+    // refine segmentation using the GMMs of the previous frame as initialization
+    ft = extractor_(trax, n_merger, max_id, initial_centers, initial_covs, initial_weights);
+  }
+  else
+  {
+    // run as before
+    LOG(logDEBUG3) << "FeatureHandlerFromTraxel::operator() -- entered for " << trax;
+    ft = extractor_(trax, n_merger, max_id);
+    LOG(logDEBUG3) << "FeatureHandlerFromTraxel::operator() -- got " << ft.size() << " new traxels";
+  }
+  
+
   for (std::vector<Traxel>::iterator it = ft.begin(); it != ft.end(); ++it) {
     // set traxel features, most of which can be copied from the merger node
     // set new center of mass as calculated from GMM
@@ -538,20 +644,15 @@ void MergerResolver::refine_node(HypothesesGraph::Node node,
   int timestep = time_map[node];
   unsigned int max_id = get_max_id(timestep)+1;
 
-  // get incoming and outgoing arcs for reorganizing arcs
+  // get active incoming and outgoing arcs for reorganizing arcs
   std::vector<HypothesesGraph::base_graph::Arc> sources;
   std::vector<HypothesesGraph::base_graph::Arc> targets;
   collect_arcs(HypothesesGraph::base_graph::InArcIt(*g_, node), sources);
   collect_arcs(HypothesesGraph::base_graph::OutArcIt(*g_, node), targets);
 
-  // instead of calling everything with traxels:
-  // write functor for extracting and setting features:
-  // FeatureHandlerBase ft_handler_(*g, node, nMerger, max_id, sources, targets, vector<unsigned int>& new_ids);
-
-
   // create new node for each of the objects merged into node
   std::vector<unsigned int> new_ids;
-  handler(*g_, node, nMerger, max_id, timestep, sources, targets, new_ids);
+  handler(*g_, node, nMerger, max_id, timestep, sources, targets, new_ids, n_dimensions_);
 
   // deactivate incoming and outgoing arcs of merger node
   // merger node will be deactivated after pruning
@@ -616,29 +717,23 @@ HypothesesGraph* MergerResolver::resolve_mergers(FeatureHandlerBase& handler) {
   LOG(logDEBUG) << "resolve_mergers() entered";
   property_map<node_active2, HypothesesGraph::base_graph>::type& active_map = g_->get(node_active2());
   property_map<node_active2, HypothesesGraph::base_graph>::type::ValueIt active_valueIt = active_map.beginValue();
-  // HypothesesGraph::node_timestep_map& timestep_map = g_->get(node_timestep());
-  // HypothesesGraph::node_timestep_map::ValueIt timestep_it = timestep_map.beginValue();
+  
+  HypothesesGraph::node_timestep_map& timestep_map = g_->get(node_timestep());
+  HypothesesGraph::node_timestep_map::ValueIt timestep_it = timestep_map.beginValue();
 
-  // std::vector<HypothesesGraph::Node> nodes_to_deactivate;
-  // for (; timestep_it != timestep_map.endValue(); ++timestep_it) {
-  //   std::cout << *timestep_it << '\n';
-  //   HypothesesGraph::node_timestep_map::ItemIt node_it(timestep_map, *timestep_it);
-  //   for (; node_it != lemon::INVALID; ++node_it) {
-  //     int count = active_map[node_it];
-  //     if (count > 1) {
-  //       std::cout << g_->id(node_it) << ' ' << count << " arcs: ";
-  //       for (HypothesesGraph::OutArcIt oa_it(*g_, node_it); oa_it != lemon::INVALID; ++oa_it) {
-  //         std::cout << g_->id(oa_it)<< ',';
-  //       }
-  //       std::cout << "\b \n";
-  //       // calculate_centers<ClusteringAlg>(active_itemIt, *active_valueIt);
-  //       // for each object create new node and set arcs to old merger node inactive (neccessary for pruning)
-  //       refine_node(node_it, count, handler);
-  //       nodes_to_deactivate.push_back(node_it);
-  //     }
-  //     std::cout << '\n' << std::endl;
-  //   }
-  // }
+  std::vector<HypothesesGraph::Node> nodes_to_deactivate;
+  for (; timestep_it != timestep_map.endValue(); ++timestep_it) {
+    HypothesesGraph::node_timestep_map::ItemIt node_it(timestep_map, *timestep_it);
+    for (; node_it != lemon::INVALID; ++node_it) {
+      int count = active_map[node_it];
+      if (count > 1) {
+        // calculate_centers<ClusteringAlg>(active_itemIt, *active_valueIt);
+        // for each object create new node and set arcs to old merger node inactive (neccessary for pruning)
+        refine_node(node_it, count, handler);
+        nodes_to_deactivate.push_back(node_it);
+      }
+    }
+  }
 
   // std::vector<HypothesesGraph::Node> nodes_to_deactivate;
   // for (; active_valueIt != active_map.endValue(); ++active_valueIt) {
@@ -654,21 +749,23 @@ HypothesesGraph* MergerResolver::resolve_mergers(FeatureHandlerBase& handler) {
   //   }
   // }
     
-  // iterate over mergers and replace merger nodes
-  // keep track of merger nodes to deactivate them later
-  std::vector<HypothesesGraph::Node> nodes_to_deactivate;
-  for (; active_valueIt != active_map.endValue(); ++active_valueIt) {
-    if (*active_valueIt > 1) {
-      property_map<node_active2, HypothesesGraph::base_graph>::type::ItemIt active_itemIt(active_map, *active_valueIt);
+  // // iterate over mergers and replace merger nodes
+  // // keep track of merger nodes to deactivate them later
+  // std::vector<HypothesesGraph::Node> nodes_to_deactivate;
+  // for (; active_valueIt != active_map.endValue(); ++active_valueIt) {
+  //   if (*active_valueIt > 1) {
+  //     property_map<node_active2, HypothesesGraph::base_graph>::type::ItemIt active_itemIt(active_map, *active_valueIt);
 	
-      for (; active_itemIt != lemon::INVALID; ++active_itemIt) {
-        // calculate_centers<ClusteringAlg>(active_itemIt, *active_valueIt);
-        // for each object create new node and set arcs to old merger node inactive (neccessary for pruning)
-        refine_node(active_itemIt, *active_valueIt, handler);
-        nodes_to_deactivate.push_back(active_itemIt);
-      }
-    }
-  }
+  //     for (; active_itemIt != lemon::INVALID; ++active_itemIt) {
+  //       // calculate_centers<ClusteringAlg>(active_itemIt, *active_valueIt);
+  //       // for each object create new node and set arcs to old merger node inactive (neccessary for pruning)
+  //       refine_node(active_itemIt, *active_valueIt, handler);
+  //       nodes_to_deactivate.push_back(active_itemIt);
+  //     }
+  //   }
+  // }
+
+
   // maybe keep merger nodes active for event extraction
   deactivate_nodes(nodes_to_deactivate);
 

--- a/src/merger_resolving.cpp
+++ b/src/merger_resolving.cpp
@@ -303,29 +303,61 @@ FeatureExtractorArmadillo::FeatureExtractorArmadillo(TimestepIdCoordinateMapPtr 
 
 std::vector<Traxel> FeatureExtractorArmadillo::operator() (Traxel& trax,
                                                            size_t nMergers,
-                                                           unsigned int max_id
-                                                           ){
-  LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() -- entered for " << trax;
-  TimestepIdCoordinateMap::const_iterator it = coordinates_->find(std::make_pair(trax.Timestep, trax.Id));
-  if (it == coordinates_->end()) {
-    throw std::runtime_error("In FeatureExtractorArmadillo: Traxel not found in coordinates.");
-  }
-  LOG(logDEBUG4) << "FeatureExtractorArmadillo::operator() -- coordinate list for " << trax
-                 << " has " << it->second.n_cols << " dimensions and "
-                 << it->second.n_rows << " points.";
-  GMMInitializeArma gmm(nMergers, it->second);
-  feature_array merger_coms = gmm();
-  update_coordinates(trax, nMergers, max_id, gmm.labels());
-  trax.features["mergerCOMs"] = feature_array(merger_coms.begin(), merger_coms.end());
-  FeatureExtractorMCOMsFromMCOMs extractor;
-  LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() -- exit";
-  return extractor(trax, nMergers, max_id);
+                                                           unsigned int max_id)
+{
+    LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() -- entered for " << trax;
+    TimestepIdCoordinateMap::const_iterator it = coordinates_->find(std::make_pair(trax.Timestep, trax.Id));
+    if (it == coordinates_->end())
+    {
+        std::stringstream msg;
+        msg << "Traxel not found in coordinates: Timestep=" << trax.Timestep << " Id=" << trax.Id;
+        throw std::runtime_error(msg.str());
+    }
+    LOG(logDEBUG4) << "FeatureExtractorArmadillo::operator() -- coordinate list for " << trax
+                   << " has " << it->second.n_cols << " dimensions and "
+                   << it->second.n_rows << " points.";
+    GMMInitializeArma gmm(nMergers, it->second);
+    feature_array merger_coms;
+    arma::Col<size_t> labels;
+    try
+    {
+         merger_coms = gmm();
+         labels = gmm.labels();
+    }
+    catch(std::exception& e)
+    {
+        LOG(logWARNING) << "GMM fitting failed for " << trax << ", reverting to KMeans: " << e.what();
+    }
+
+    // get pixel labels, and if one label did not get assigned to any pixels, run kmeans and use its assignments as labels
+    arma::Col<size_t> unique_labels = arma::unique(labels);
+    if(unique_labels.n_elem != nMergers)
+    {
+        LOG(logINFO) << "Falling back to kmeans pixel labeling for " << trax << ", as GMMs did not assign each label to at least one pixel";
+        arma::mat centers(3, nMergers);
+        mlpack::kmeans::KMeans<> kMeans;
+        kMeans.Cluster(it->second, nMergers, labels, centers);
+        merger_coms.clear();
+        for (size_t c = 0; c < nMergers; c++)
+        {
+            merger_coms.push_back(centers(0,c));
+            merger_coms.push_back(centers(1,c));
+            merger_coms.push_back(centers(2,c));
+        }
+    }
+
+    // update coordinates and traxels based on this information
+    update_coordinates(trax, nMergers, max_id, labels);
+    trax.features["mergerCOMs"] = merger_coms;
+    FeatureExtractorMCOMsFromMCOMs extractor;
+    LOG(logDEBUG3) << "FeatureExtractorArmadillo::operator() -- exit";
+    return extractor(trax, nMergers, max_id);
 }
 
 void FeatureExtractorArmadillo::update_coordinates(const Traxel& trax,
                                                    size_t nMergers,
                                                    unsigned int max_id,
-                                                   arma::Col<size_t> labels
+                                                   arma::Col<size_t>& labels
                                                    ) {
   LOG(logDEBUG4) << "in FeatureExtractorArmadillo::update_coordinates";
   TimestepIdCoordinateMap::iterator it = coordinates_->find(std::make_pair(trax.Timestep, trax.Id));
@@ -343,7 +375,6 @@ void FeatureExtractorArmadillo::update_coordinates(const Traxel& trax,
   }
   coordinates_->erase(it);
 }
-
 
 ////
 //// FeatureHandlerBase

--- a/src/merger_resolving.cpp
+++ b/src/merger_resolving.cpp
@@ -458,7 +458,6 @@ void FeatureHandlerFromTraxels::operator()(
     // set new center of mass as calculated from GMM
     // add node to graph and activate it
     HypothesesGraph::Node new_node = g.add_node(timestep);
-    // MAYBE LOG
     traxel_map.set(new_node, *it);
     active_map.set(new_node, 1);
     time_map.set(new_node, timestep);
@@ -487,14 +486,6 @@ double DistanceFromCOMs::operator()(const HypothesesGraph& g, HypothesesGraph::N
 
 double DistanceFromCOMs::operator()(Traxel from, Traxel to) {
   return from.distance_to(to);
-}
-
-////
-//// ResolveAmbiguousArcsGreedy
-////
-HypothesesGraph& ResolveAmbiguousArcsGreedy::operator()(HypothesesGraph* g) {
-    
-  return *g;
 }
 
 

--- a/src/tracking.cpp
+++ b/src/tracking.cpp
@@ -554,7 +554,7 @@ boost::shared_ptr<HypothesesGraph> ConsTracking::build_hypo_graph(TraxelStore& t
             HypothesesGraph resolved_graph;
             HypothesesGraph::copy(*hypotheses_graph_, resolved_graph);
 
-            MergerResolver m(&resolved_graph);
+            MergerResolver m(&resolved_graph, n_dim);
 			FeatureExtractorBase* extractor;
 			DistanceFromCOMs distance;
 			if (coordinates) {

--- a/tests/merger_resolver_test.cpp
+++ b/tests/merger_resolver_test.cpp
@@ -31,7 +31,7 @@ using namespace std;
 using namespace boost;
 
 
-BOOST_AUTO_TEST_CASE( MergerResolver_no_mergers ) {
+BOOST_AUTO_TEST_CASE( MergerResolver_no_mergers) {
   HypothesesGraph src;
   HypothesesGraph dest;
 
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_no_mergers ) {
     .add(arc_resolution_candidate())
     .add(arc_distance());
 
-  MergerResolver m(&src);
+  MergerResolver m(&src, 2);
   FeatureExtractorMCOMsFromGMM extractor(2);
   DistanceFromCOMs distance;
   FeatureHandlerFromTraxels handler(extractor, distance);
@@ -117,13 +117,13 @@ BOOST_AUTO_TEST_CASE( MergerResolver_subgraph ) {
 
 BOOST_AUTO_TEST_CASE( MergerResolver_constructor ) {
   HypothesesGraph g;
-  BOOST_CHECK_THROW(MergerResolver m(&g), std::runtime_error);
+  BOOST_CHECK_THROW(MergerResolver m(&g, 2), std::runtime_error);
   g.add(node_active2());
-  BOOST_CHECK_THROW(MergerResolver m(&g), std::runtime_error);
+  BOOST_CHECK_THROW(MergerResolver m(&g, 2), std::runtime_error);
   g.add(arc_active());
-  BOOST_CHECK_THROW(MergerResolver m(&g), std::runtime_error);
+  BOOST_CHECK_THROW(MergerResolver m(&g, 2), std::runtime_error);
   g.add(arc_distance());
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   BOOST_CHECK_EQUAL(m.g_, &g);
   // check that merger_resolved_to property has been added
   BOOST_CHECK(m.g_->has_property(merger_resolved_to()));
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_constructor ) {
 
   // check exception on intialization with null pointer
   HypothesesGraph* G = 0; // = hyp_builder.build();
-  BOOST_CHECK_THROW(MergerResolver M(G), std::runtime_error);
+  BOOST_CHECK_THROW(MergerResolver M(G, 2), std::runtime_error);
 }
 
 
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_resolve_mergers_3 ) {
 
   property_map<arc_distance, HypothesesGraph::base_graph>::type& dist_map = g.get(arc_distance());
 
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   FeatureExtractorMCOMsFromPCOMs extractor;
   DistanceFromCOMs distance;
   FeatureHandlerFromTraxels handler(extractor, distance);
@@ -388,7 +388,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_resolve_mergers_2 ) {
   active_map.set(n31, 1);
   active_map.set(n32, 1);
 
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   FeatureExtractorMCOMsFromPCOMs extractor;
   DistanceFromCOMs distance;
   FeatureHandlerFromTraxels handler(extractor, distance);
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_resolve_mergers ) {
   active_map.set(n12, 1);
   active_map.set(n21, 2);
 
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   FeatureExtractorMCOMsFromPCOMs extractor;
   DistanceFromCOMs distance;
   FeatureHandlerFromTraxels handler(extractor, distance);
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_refine_node ) {
   property_map<arc_distance, HypothesesGraph::base_graph>::type& distance_map = g.get(arc_distance());
   
 
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   FeatureExtractorMCOMsFromMCOMs extractor;
   DistanceFromCOMs distance;
   FeatureHandlerFromTraxels handler(extractor, distance);
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_deactivate_arcs ) {
   std::vector<HypothesesGraph::base_graph::Arc> arcs;
   arcs.push_back(a12);
   arcs.push_back(a23);
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   m.deactivate_arcs(arcs);
   for (std::vector<HypothesesGraph::base_graph::Arc>::iterator it = arcs.begin(); it != arcs.end(); ++it) {
     // arc is deactivated
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_deactivate_nodes ) {
 
   std::vector<HypothesesGraph::Node> nodes;
   nodes.push_back(n);
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   m.deactivate_nodes(nodes);
   property_map<node_active2, HypothesesGraph::base_graph>::type& active_map = g.get(node_active2());
   property_map<node_active2, HypothesesGraph::base_graph>::type::ValueIt active_It=active_map.beginValue();
@@ -838,7 +838,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_get_max_id ) {
   traxel_map.set(n12, t12);
   traxel_map.set(n21, t21);
 
-  MergerResolver m(&g);
+  MergerResolver m(&g, 2);
   BOOST_CHECK_EQUAL(m.get_max_id(1), 2);
   BOOST_CHECK_EQUAL(m.get_max_id(2), 2);  
 }
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE( MergerResolver_collect_arcs ) {
   SingleTimestepTraxel_HypothesesBuilder hyp_builder(&ts, builder_opts);
   HypothesesGraph* g = hyp_builder.build();
   g->add(node_active2()).add(arc_active()).add(arc_distance());
-  MergerResolver m(g);
+  MergerResolver m(g, 2);
   
   std::vector<HypothesesGraph::base_graph::Arc> sources;
   std::vector<HypothesesGraph::base_graph::Arc> targets;


### PR DESCRIPTION
Whenever possible, we now use the positions of the predecessors at `t` of a merger at `t+1` to initialize the GMM fitting when resolving mergers. This runs from `t=0` to `t=Tmax` such that we can even propagate this information when mergers remain connected for more than one frame.

It seems to help quite a lot, here's for instance the result on my example dataset for this problem:
![result 001](https://cloud.githubusercontent.com/assets/16854/11692155/78e13e70-9e9e-11e5-9e13-53b63852f7a1.png)